### PR TITLE
Updated zwave2mqtt to version 1.1.2

### DIFF
--- a/zwave2mqtt/Dockerfile
+++ b/zwave2mqtt/Dockerfile
@@ -38,7 +38,7 @@ RUN \
     && mv /tmp/db/config /usr/etc/openzwave \
     \
     && curl -J -L -o /tmp/zwave2mqtt.tar.gz \
-        "https://github.com/OpenZWave/Zwave2Mqtt/archive/1.0.0.tar.gz" \
+        "https://github.com/OpenZWave/Zwave2Mqtt/archive/v1.1.2.tar.gz" \
     && tar zxvf \
         /tmp/zwave2mqtt.tar.gz \
         --strip 1 -C /opt \


### PR DESCRIPTION
# Proposed Changes

Updated Zwave2Mqtt to version 1.1.2

## Related Issues

#3 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/