### PR TITLE
Update openzwave-db

### DIFF
--- a/zwave2mqtt/Dockerfile
+++ b/zwave2mqtt/Dockerfile
@@ -28,7 +28,7 @@ RUN \
         openzwave=1.4.164-r4 \
     \
     && curl -J -L -o /tmp/openzwave-db.tar.gz \
-        "https://github.com/OpenZWave/open-zwave/archive/3d6374c831998595744cc34ef862a80ee51973c9.tar.gz" \
+        "https://github.com/OpenZWave/open-zwave/archive/76e21d80a140c321413a46a2b62ea6c11dd6ace0.tar.gz" \
     && mkdir /tmp/db \
     && tar zxvf \
         /tmp/openzwave-db.tar.gz \


### PR DESCRIPTION
I ran into the issue that my Fibaro Dimmer 2 (FGD-212) wasn't recognized and resulted in the following product in the control panel:

Unknown: type=0102, id=1000 (Unknown: id=010f)

Looking at the commits done on the OpenZwave repo after the previous version that was downloaded I expect this dimmer to be recognized. I am not sure why `3d6374c831998595744cc34ef862a80ee51973c9` was used until now, but this PR updates to the latest on `master`. Is there a reason not to update to the latest OpenZwave DB?

# Proposed Changes

Update OpenZwave DB

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/