### PR TITLE
Update OpenZwave DB to latest on 1.4

### DIFF
--- a/zwave2mqtt/Dockerfile
+++ b/zwave2mqtt/Dockerfile
@@ -28,7 +28,7 @@ RUN \
         openzwave=1.4.164-r4 \
     \
     && curl -J -L -o /tmp/openzwave-db.tar.gz \
-        "https://github.com/OpenZWave/open-zwave/archive/3d6374c831998595744cc34ef862a80ee51973c9.tar.gz" \
+        "https://github.com/OpenZWave/open-zwave/archive/76e21d80a140c321413a46a2b62ea6c11dd6ace0.tar.gz" \
     && mkdir /tmp/db \
     && tar zxvf \
         /tmp/openzwave-db.tar.gz \

--- a/zwave2mqtt/Dockerfile
+++ b/zwave2mqtt/Dockerfile
@@ -28,7 +28,7 @@ RUN \
         openzwave=1.4.164-r4 \
     \
     && curl -J -L -o /tmp/openzwave-db.tar.gz \
-        "https://github.com/OpenZWave/open-zwave/archive/76e21d80a140c321413a46a2b62ea6c11dd6ace0.tar.gz" \
+        "https://github.com/OpenZWave/open-zwave/archive/449f89f063effb048f5dd6348d509a6c54fd942d.tar.gz" \
     && mkdir /tmp/db \
     && tar zxvf \
         /tmp/openzwave-db.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Update OpenZwave

## Related Issues

https://github.com/hassio-addons/addon-zwave2mqtt/pull/19

I'm really sorrry, I don't want to spam PR's, but I was unable to do anything with the closed PR. I will copy / paste that last comment. Could you have another look at my suggestion?

When looking at the docker of Zwave2Mqtt itself it is actually using the config / db files from the 1.4 branch: https://github.com/robertsLando/Zwave2Mqtt-docker/blob/master/Dockerfile while the addon uses a config from the 1.6 / master branch: 3d6374c831998595744cc34ef862a80ee51973c9

Shouldn't the zwave2mqtt addon at least use the db from the 1.4 branch opposed to the 1.6 branch commit it is now using?

And otherwise maybe pointing me into a direction how to get my Fibaro FGD 212 recognized?

<blockquote><img src="https://avatars2.githubusercontent.com/u/11502495?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/robertsLando/Zwave2Mqtt-docker">robertsLando/Zwave2Mqtt-docker</a></strong></div><div>Docker container for Zwave2Mqtt Gateway and Control Panel app - robertsLando/Zwave2Mqtt-docker</div></blockquote>