### PR TITLE
Fix build issue with docker container

### DIFF
--- a/zwave2mqtt/Dockerfile
+++ b/zwave2mqtt/Dockerfile
@@ -5,12 +5,15 @@ FROM ${BUILD_FROM}
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+#add repository source
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.10/main" >> /etc/apk/repositories
+
 # Setup base
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r1 \
-        git=2.22.0-r0 \
+        git=2.22.2-r0 \
         linux-headers=4.19.36-r0 \
         npm=10.16.3-r0 \
         openzwave-dev=1.4.164-r4 \
@@ -24,7 +27,7 @@ RUN \
         nginx-mod-http-lua=1.16.1-r1 \
         nginx=1.16.1-r1 \
         nodejs=10.16.3-r0 \
-        openssl=1.1.1d-r0 \
+        openssl=1.1.1d-r2 \
         openzwave=1.4.164-r4 \
     \
     && curl -J -L -o /tmp/openzwave-db.tar.gz \


### PR DESCRIPTION
Added reference to the non edge repo location that contains the packages used by the zwave2mqtt addon

# Proposed Changes
The current zwave2mqtt Docker image isn't building anymore.
Therefore, I added a reference to the alpine repo that has (almost) all of the required package versions.
Thereby, making it possible to build the addon again*.


Failed build link:
https://gitlab.com/hassio-addons/addon-zwave2mqtt/-/jobs/377051535

*Eventually the used packages will need to be updated. So the addon can use the latest alpine repo again.

<blockquote><img src="https://assets.gitlab-static.net/assets/gitlab_logo-7ae504fe4f68fdebb3c2034e36621930cd36ea87924c11ff65dbcb8ed50dca58.png" width="48" align="right"><div>GitLab</div><div><strong><a href="https://gitlab.com/hassio-addons/addon-zwave2mqtt/-/jobs/377051535">build:aarch64 (#377051535) · Jobs · Community Hass.io Add-ons / addon-zwave2mqtt</a></strong></div><div>Z-Wave to MQTT - Community Hass.io Add-on for Home Assistant</div></blockquote>